### PR TITLE
Speed up selfloop and repetition functions by replacing `dplyr` methods with `data.table`

### DIFF
--- a/R/repetitions_all.R
+++ b/R/repetitions_all.R
@@ -18,10 +18,10 @@ all_repetitions <- function(eventlog) {
 		as.data.table %>%
 		.[, trace_length := .N, by = .(case_classifier)] %>%
 		.[, activity_frequency := .N, by = .(event_classifier)] %>%
-		.[, .(length = n_distinct(activity_group),
-			  nr_of_resources = n_distinct(resource_classifier),
-			  first_resource = data.table::first(resource_classifier),
-			  last_resource = data.table::last(resource_classifier)),
+		.[, .(length = data.table::uniqueN(activity_group),
+			  nr_of_resources = data.table::uniqueN(resource_classifier),
+			  first_resource = resource_classifier[1],
+			  last_resource = resource_classifier[.N]),
 		  .(case_classifier, event_classifier, trace_length, activity_frequency)]%>%
 		.[length > 1]	%>%
 		.[, length := length -1] %>%

--- a/R/repetitions_redo.R
+++ b/R/repetitions_redo.R
@@ -18,10 +18,10 @@ redo_repetitions <- function(eventlog) {
 		as.data.table %>%
 		.[, trace_length := .N, by = .(case_classifier)] %>%
 		.[, activity_frequency := .N, by = .(event_classifier)] %>%
-		.[, .(length = n_distinct(activity_group),
-			  nr_of_resources = n_distinct(resource_classifier),
-			  first_resource = data.table::first(resource_classifier),
-			  last_resource = data.table::last(resource_classifier)),
+		.[, .(length = data.table::uniqueN(activity_group),
+			  nr_of_resources = data.table::uniqueN(resource_classifier),
+			  first_resource = resource_classifier[1],
+			  last_resource = resource_classifier[.N]),
 		  .(case_classifier, event_classifier, trace_length, activity_frequency)]%>%
 		.[nr_of_resources > 1 &  length > 1]	%>%
 		.[, length := length -1] %>%

--- a/R/repetitions_repeat.R
+++ b/R/repetitions_repeat.R
@@ -18,7 +18,9 @@ repeat_repetitions <- function(eventlog) {
 		as.data.table %>%
 		.[, trace_length := .N, by = .(case_classifier)] %>%
 		.[, activity_frequency := .N, by = .(event_classifier)] %>%
-		.[, .(length = n_distinct(activity_group), nr_of_resources = n_distinct(resource_classifier), resource_classifier = first(resource_classifier)),
+		.[, .(length = data.table::uniqueN(activity_group),
+			  nr_of_resources = data.table::uniqueN(resource_classifier),
+			  resource_classifier = resource_classifier[1]),
 		  .(case_classifier, event_classifier, trace_length, activity_frequency)]%>%
 		.[nr_of_resources == 1 &  length > 1]	%>%
 		.[, length := length -1] %>%

--- a/R/rework_base.R
+++ b/R/rework_base.R
@@ -21,8 +21,8 @@ rework_base <- function(eventlog) {
 		as.data.table %>%
 		.[, .(timestamp = min(timestamp_classifier), min_order = min(.order)), .(case_classifier, aid, event_classifier, resource_classifier)] %>%
 		.[order(timestamp, min_order), .SD , by =  .(case_classifier)] %>%
-		.[,next_activity := lead(event_classifier), .(case_classifier)] %>%
-		.[, same_activity := lag(event_classifier == next_activity)] %>%
+		.[, next_activity := shift(event_classifier, type='lead'), .(case_classifier)] %>%
+		.[, same_activity := shift(event_classifier == next_activity, type='lag')] %>%
 		.[, same_activity := ifelse(is.na(same_activity), FALSE, same_activity)]  %>%
 		.[, activity_group := paste(case_classifier, cumsum(!same_activity), sep = "-")] %>%
 		.[,.(case_classifier, aid, event_classifier, resource_classifier, activity_group)] %>%

--- a/R/selfloops_all.R
+++ b/R/selfloops_all.R
@@ -14,7 +14,7 @@ all_selfloops <- function(eventlog) {
 	t_length <- NULL
 
 	eventlog %>%
-		rework_base()-> r
+		rework_base() -> r
 
 	r %>%
 		rename("case_classifier" = !!case_id_(eventlog),
@@ -24,9 +24,9 @@ all_selfloops <- function(eventlog) {
 		.[, trace_length := .N, by = .(case_classifier)] %>%
 		.[, activity_frequency := .N, by = .(event_classifier)] %>%
 		.[, .(t_length = .N,
-			  nr_of_resources = n_distinct(resource_classifier),
-			  first_resource = first(resource_classifier),
-			  last_resource = last(resource_classifier)),
+			  nr_of_resources = data.table::uniqueN(resource_classifier),
+			  first_resource = resource_classifier[1],
+			  last_resource = resource_classifier[.N]),
 		  .(case_classifier, activity_group, event_classifier, trace_length, activity_frequency)] %>%
 		.[  t_length > 1] %>%
 		.[, length := t_length -1] %>%

--- a/R/selfloops_redo.R
+++ b/R/selfloops_redo.R
@@ -24,9 +24,9 @@ redo_selfloops <- function(eventlog) {
 		.[, trace_length := .N, by = .(case_classifier)] %>%
 		.[, activity_frequency := .N, by = .(event_classifier)] %>%
 		.[, .(t_length = .N,
-			  nr_of_resources = n_distinct(resource_classifier),
-			  first_resource = first(resource_classifier),
-			  last_resource = last(resource_classifier)),
+			  nr_of_resources = data.table::uniqueN(resource_classifier),
+			  first_resource = resource_classifier[1],
+			  last_resource = resource_classifier[.N]),
 		  .(case_classifier, activity_group, event_classifier, trace_length, activity_frequency)] %>%
 		.[nr_of_resources > 1 &  t_length > 1] %>%
 		.[, length := t_length -1] %>%

--- a/R/selfloops_repeat.R
+++ b/R/selfloops_repeat.R
@@ -18,7 +18,9 @@ repeat_selfloops <- function(eventlog) {
 		as.data.table %>%
 		.[, trace_length := .N, by = .(case_classifier)] %>%
 		.[, activity_frequency := .N, by = .(event_classifier)] %>%
-		.[, .(t_length = .N, nr_of_resources = n_distinct(resource_classifier), resource_classifier = first(resource_classifier)),
+		.[, .(t_length = .N,
+			  nr_of_resources = data.table::uniqueN(resource_classifier),
+			  resource_classifier = resource_classifier[1]),
 		  .(case_classifier, activity_group, event_classifier, trace_length, activity_frequency)] %>%
 		.[nr_of_resources == 1 &  t_length > 1] %>%
 		.[, length := t_length -1] %>%


### PR DESCRIPTION
This PR replaces `dplyr` methods with `data.table` methods for a couple of `_selfloop` and `_repetitions` functions.

The changes were tested on the `hospital`, `hospital_billings`, `patients`, `sepsis`, `traffic_fines`.
The numbers reported below are approximately how much *less* time the new function takes to complete, so 50% less time to run = 2x as fast. The exact decrease in runtime depends on the dataset, but this version is quicker for all of the default datasets. 

Comparing the median runtime of the current method to the median of the version in this PR:

* `all_repetitions`: ~35% to 45% less time to run
* `redo_repetitions`: ~37% to 46% less time to run
* `repeat_repetitions`: ~50% to ~60% less time to run
---

* `all_selfloops`: ~60% to ~70% less time to run
* `redo_selfloops`: ~70% less time to run
* `repeat_selfloops`: ~65 to ~70% less time to run

